### PR TITLE
terraform: only one node security group can be tag as owned by the EK…

### DIFF
--- a/terraform/module-eks-node/nodes.tf
+++ b/terraform/module-eks-node/nodes.tf
@@ -15,10 +15,9 @@ resource "aws_security_group" "eks-node" {
   }
 
   tags = merge(local.merged_tags, {
-    Name                                        = "${var.project}-${var.env}-eks-node-${var.node_group_name}"
-    role                                        = "eks-node"
-    "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-    "kubernetes.io/nodegroup/name"             = "${var.node_group_name}"
+    Name                           = "${var.project}-${var.env}-eks-node-${var.node_group_name}"
+    role                           = "eks-node"
+    "kubernetes.io/nodegroup/name" = "${var.node_group_name}"
   })
 }
 


### PR DESCRIPTION
…S cluster

eg. of error:

```
Warning  UpdateLoadBalancerFailed  19m (x31 over 6h49m)    service-controller  Error updating load balancer with new hosts map[ip-10-8-0-246.eu-west-1.compute.internal:{} ip-10-8-2-13.eu-west-1.compute.internal:{} ip-10-8-4-191.eu-west-1.compute.internal:{} ip-10-8-4-25.eu-west-1.compute.internal:{}]: Multiple tagged security groups found for instance i-00cd16a77a72358e9; ensure only the k8s security group is tagged; the tagged groups were sg-0d15f6d7abb7735fe(kubernetes-infra-eks-nodes) sg-0f1c5d9f3794d3e20(kubernetes-prod-eks-node-application)
```