### PR TITLE
terraform: allow all IPs to access the API by default as terraform do…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ In order to run this task, couple elements are required within the infrastructur
 |`bastion_sg_allow`|Additionnal security group ID to assign to servers. Goal is to allow bastion server to connect on nodes port 22 (SSH). Make sure the bastion VPC is peered.|`-`|``|`False`|
 |`cluster_enabled_log_types`|EKS cluster enabled log types.|`-`|`["api", "audit", "authenticator", "controllerManager", "scheduler"]`|`False`|
 |`cluster_version`|EKS cluster version.|`-`|`1.16`|`False`|
-|`control_plane_allowed_ips`|Allow Inbound IP CIDRs to access the Kubernetes API.|`-`|`[]`|`False`|
+|`control_plane_allowed_ips`|Allow Inbound IP CIDRs to access the Kubernetes API.|`-`|`["0.0.0.0/0"]`|`False`|
 |`enable_dynamodb_endpoint`|Should be true if you want to provision a DynamoDB endpoint to the VPC.|`bool`|`false`|`False`|
 |`enable_s3_endpoint`|Should be true if you want to provision an S3 endpoint to the VPC.|`bool`|`false`|`False`|
 |`extra_tags`|Dict of extra tags to add on aws resources. format { "foo" = "bar" }.|`-`|`{}`|`False`|

--- a/terraform/eks.tf.sample
+++ b/terraform/eks.tf.sample
@@ -115,7 +115,7 @@ module "eks" {
   #. cluster_enabled_log_types (optional): ["api", "audit", "authenticator", "controllerManager", "scheduler"]
   #+ EKS cluster enabled log types.
 
-  #. control_plane_allowed_ips (optional): [] 
+  #. control_plane_allowed_ips (optional): ["0.0.0.0/0"] 
   #+ Allow Inbound IP CIDRs to access the Kubernetes API.
 
   ###

--- a/terraform/module-eks/variables.tf
+++ b/terraform/module-eks/variables.tf
@@ -84,5 +84,5 @@ variable "cluster_enabled_log_types" {
 
 variable "control_plane_allowed_ips" {
   description = "Allow Inbound IP CIDRs to access the Kubernetes API."
-  default     = []
+  default     = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
…esn't like an empty list

This will fix the following error:
```
One of ['cidr_blocks', 'ipv6_cidr_blocks', 'self', 'source_security_group_id', 'prefix_list_ids'] must be set to create an AWS Security Group Rule
```