### PR TITLE
terraform eks: use aws-iam-authenticator as kubeconfig client

### DIFF
--- a/terraform/module-eks/outputs.tf
+++ b/terraform/module-eks/outputs.tf
@@ -71,16 +71,23 @@ users:
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
-      command: aws
+      command: aws-iam-authenticator
       args:
-        - --region
-        - "${data.aws_region.current.name}"
-        - eks
-        - get-token
-        - --cluster-name
+        - "token"
+        - "-i"
         - "${var.cluster_name}"
 KUBECONFIG
 }
+
+# The following lines can be used to generate kubeconfig using awscli as authentication client
+# command: aws
+# args:
+#   - --region
+#   - "${data.aws_region.current.name}"
+#   - eks
+#   - get-token
+#   - --cluster-name
+#   - "${var.cluster_name}"
 
 output "kubeconfig" {
   description = "Kubernetes config to connect to the EKS Cluster."


### PR DESCRIPTION
as concourse kubernetes-resource doesn't have aws cli supported yet,
generate the kubeconfig with aws-iam-authenticator to keep consistency